### PR TITLE
Typos in examples fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ wAsync is a Java based library allowing asynchronous communication with any WebS
 You can browse the [javadoc](http://atmosphere.github.com/wasync/apidocs/) As simple as
 
 ```java
-        Client client = ClientFactory.getDefault().newclient();
+        Client client = ClientFactory.getDefault().newClient();
 
         RequestBuilder request = client.newRequestBuilder()
                 .method(Request.METHOD.GET)
@@ -21,8 +21,8 @@ You can browse the [javadoc](http://atmosphere.github.com/wasync/apidocs/) As si
                         return new StringReader(s);
                     }
                 })
-                .transport(WEBSOCKET)                        // Try WebSocket
-                .transport(LONG_POLLING);                    // Fallback to Long-Polling
+                .transport(Request.TRANSPORT.WEBSOCKET)                        // Try WebSocket
+                .transport(Request.TRANSPORT.LONG_POLLING);                    // Fallback to Long-Polling
 
         Socket socket = client.create();
         socket.on(new Function<Reader>() {

--- a/wasync/src/main/java/org/atmosphere/wasync/Socket.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/Socket.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeoutException;
  * A Socket represent a connection to a remote server. A Socket abstract the transport used, the client will negotiate
  * the best {@link org.atmosphere.wasync.Request#transport()} to communicate with the remote Server. As simple as
  * <blockquote><pre>
-     Client client = AtmosphereClientFactory.getDefault().newclient();
+     Client client = AtmosphereClientFactory.getDefault().newClient();
 
      RequestBuilder request = client.newRequestBuilder()
              .method(Request.METHOD.GET)
@@ -40,8 +40,8 @@ import java.util.concurrent.TimeoutException;
                      return new StringReader(s);
                  }
              })
-             .transport(WEBSOCKET)                        // Try WebSocket
-             .transport(LONG_POLLING);                    // Fallback to Long-Polling
+             .transport(Request.TRANSPORT.WEBSOCKET)                        // Try WebSocket
+             .transport(Request.TRANSPORT.LONG_POLLING);                    // Fallback to Long-Polling
 
      Socket socket = client.create();
      socket.on("message", new Function&lt;String&gt;() {


### PR DESCRIPTION
- ClientFactory.getDefault().newclient() -> .newClient()
- Added "Request.TRANSPORT." before WEBSOCKET and LONG_POLLING references
