### PR TITLE
Make invokeEncoder play nice with polymorphism.

### DIFF
--- a/wasync/src/main/java/org/atmosphere/wasync/impl/DefaultSocket.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/impl/DefaultSocket.java
@@ -219,7 +219,7 @@ public class DefaultSocket implements Socket {
             for (Encoder e : encoders) {
                 Class<?>[] typeArguments = TypeResolver.resolveArguments(e.getClass(), Encoder.class);
 
-                if (typeArguments.length > 0 && typeArguments[0].equals(instanceType.getClass())) {
+                if (typeArguments.length > 0 && typeArguments[0].isAssignableFrom(instanceType.getClass())) {
                     instanceType = e.encode(instanceType);
                 }
             }


### PR DESCRIPTION
Hi JeanFrancois

I was running into the issue of not being able to define a single encoder that could deal with my entire set of application protocol messages, all inheriting fom a common parent (IOutgoingPacket). An encoder like this:

``` java
@Override
public byte[] encode(IOutgoingPacket outgoingPacket) {
    ChannelBuffer packetBuffer = outgoingPacket.getPacketBuffer();
    return packetBuffer.array();
}
```

There is an easy fix to make invokeEncoder play nice with polymorphism. Stepping away from equals makes the match depend on the ordering of encoders though.... In other words you might see a need to come up with a more fancy encoder matching algorithm.

On the other hand one could argue that you either go with a generic encoder or with many specific ones, and the suggested patch is good enough. It sure is for my case :)

Let me know what you think.

Cheers, Christian.
