### PR TITLE
Don't convert incoming binary payloads to String.

### DIFF
--- a/wasync/src/main/java/org/atmosphere/wasync/transport/StreamTransport.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/transport/StreamTransport.java
@@ -95,10 +95,15 @@ public class StreamTransport<T> implements AsyncHandler<String>, Transport {
      */
     @Override
     public STATE onBodyPartReceived(HttpResponseBodyPart bodyPart) throws Exception {
-        String m = new String(bodyPart.getBodyPartBytes(), charSet).trim();
-        if (!m.isEmpty()) {
-            TransportsUtil.invokeFunction(decoders, functions, m.getClass(), m, Function.MESSAGE.message.name(), resolver);
-        }
+    	if(request.headers().get("Content-Type").contains("application/octet-stream")) {
+    		byte[] payload = bodyPart.getBodyPartBytes();
+    		TransportsUtil.invokeFunction(decoders, functions, payload.getClass(), payload, Function.MESSAGE.message.name(), resolver);
+    	} else {
+    		String m = new String(bodyPart.getBodyPartBytes(), charSet).trim();
+    		if (!m.isEmpty()) {
+    			TransportsUtil.invokeFunction(decoders, functions, m.getClass(), m, Function.MESSAGE.message.name(), resolver);
+    		}
+    	}
         return STATE.CONTINUE;
     }
 


### PR DESCRIPTION
Hi JeanFrancois

The `StreamTransport.onBodyPartReceived()` method converts any incoming payload to a String, irrespective of Content-Type.

My pull-request is just a proposal, it has "magic numbers": Content-Type and application/octet-stream. Those should be refering to public constants somewhere in the code base, I guess. And furthermore, you might want to make it more flexible on what content-types a client considers being binary.

Cheers, Christian.
