### PR TITLE
remove wrong if

### DIFF
--- a/wasync/src/main/java/org/atmosphere/wasync/impl/DefaultSocket.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/impl/DefaultSocket.java
@@ -216,15 +216,13 @@ public class DefaultSocket implements Socket {
     }
 
     void closeRuntime(boolean async) {
-        if (options.runtimeShared()) {
-            if (!options.runtimeShared() && !options.runtime().isClosed()) {
-                if (async == true)
-                    options.runtime().closeAsynchronously();
-                else
-                    options.runtime().close();
-            } else if (options.runtimeShared()) {
-                logger.warn("Cannot close underlying AsyncHttpClient because it is shared. Make sure you close it manually.");
-            }
+        if (!options.runtimeShared() && !options.runtime().isClosed()) {
+            if (async == true)
+                options.runtime().closeAsynchronously();
+            else
+                options.runtime().close();
+        } else if (options.runtimeShared()) {
+            logger.warn("Cannot close underlying AsyncHttpClient because it is shared. Make sure you close it manually.");
         }
     }
 


### PR DESCRIPTION
The outer if makes the inner condition not working. I'm not sure, but if the options is not shared between clients. The inner will not work. Is this expected behaviour?
