### PR TITLE
BinaryEchoTest over LongPolling.

### DIFF
--- a/wasync/src/test/java/org/atmosphere/tests/LongPollingTest.java
+++ b/wasync/src/test/java/org/atmosphere/tests/LongPollingTest.java
@@ -1,5 +1,18 @@
 package org.atmosphere.tests;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.atmosphere.cpr.ApplicationConfig;
 import org.atmosphere.cpr.AtmosphereHandler;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.AtmosphereResourceEvent;
@@ -12,17 +25,6 @@ import org.atmosphere.wasync.RequestBuilder;
 import org.atmosphere.wasync.Socket;
 import org.atmosphere.wasync.impl.AtmosphereClient;
 import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 
 public class LongPollingTest extends StreamingTest {
 
@@ -39,6 +41,92 @@ public class LongPollingTest extends StreamingTest {
     @Override
     int notFoundCode() {
         return 404;
+    }
+    
+    @Test
+    public void BinaryEchoTest() throws Exception {
+    	Config config = new Config.Builder()
+    		.port(port)
+    		.host("127.0.0.1")    	
+    		.resource("/suspend", new AtmosphereHandler() {
+
+        	@Override
+        	public void onRequest(AtmosphereResource resource) throws IOException {
+        		if (resource.getRequest().getMethod().equals("GET")) {
+        			resource.suspend(-1);
+        		} else {
+        			int payloadSize = resource.getRequest().getContentLength();
+					byte[] payload = new byte[payloadSize];
+					try {
+						resource.getRequest().getInputStream().read(payload);
+					} catch (Exception e) {
+						e.printStackTrace();
+					}
+        			logger.info("echoing : {}", payload);
+        			resource.getBroadcaster().broadcast(payload);
+        		}
+        	}
+
+        	@Override
+        	public void onStateChange(AtmosphereResourceEvent event) throws IOException {
+        		if (!(event.isResuming()) || event.isResumedOnTimeout() || event.isSuspended()) {
+    				// make the GET reply have binary content type
+    				event.getResource().getResponse().setContentType("application/octet-stream");
+    				// make it use the OutputStream directly in writing, prevent any String conversions.
+    				event.getResource().getRequest().setAttribute(ApplicationConfig.PROPERTY_USE_STREAM, true);
+    				// do the actual write
+    				event.getResource().getResponse().write((byte[])event.getMessage());        
+        			event.getResource().resume();
+        		}
+        	}
+        	
+        	@Override
+        	public void destroy() {
+        		
+        	}
+        	
+        }).build();
+
+    	Nettosphere server = new Nettosphere.Builder().config(config).build();
+    	assertNotNull(server);
+    	server.start();
+   
+    	final CountDownLatch latch = new CountDownLatch(1);
+    	final AtomicBoolean hasEchoReplied = new AtomicBoolean(false);
+    	AtmosphereClient client = ClientFactory.getDefault().newClient(AtmosphereClient.class);
+    	
+    	final byte[] binaryEcho = new byte[] {1,2,3,4};
+
+    	RequestBuilder request = client.newRequestBuilder()
+		   .method(Request.METHOD.GET)
+		   .uri(targetUrl + "/suspend")
+		   .header("Content-Type", "application/octet-stream")
+		   .transport(Request.TRANSPORT.LONG_POLLING);
+
+    	Socket socket = client.create(client.newOptionsBuilder().build());
+
+    	socket.on("message", new Function<byte[]>() {    		
+    		@Override
+    		public void on(byte[] message) {
+    			logger.info("received : {}", message);
+    			if (message.equals(binaryEcho)) {
+    				hasEchoReplied.getAndSet(true);
+    			}
+    			latch.countDown();
+    		}
+    	}).on(new Function<Throwable>() {
+    		@Override
+    		public void on(Throwable t) {
+    			t.printStackTrace();
+    		}
+    	}).open(request.build());
+
+    	socket.fire(binaryEcho).get();
+    	
+    	latch.await(2, TimeUnit.SECONDS);
+    	socket.close();
+
+    	assertEquals(hasEchoReplied.get(), true);
     }
     
     @Test


### PR DESCRIPTION
Hi Jeanfrancois 

this is an echo test, with one binary echo message being sent in and expected to be echoed.

Currently it fails and illustrates nicely the "connection establishment" in `socket.connect()` going crazy, once the `.header("Content-Type", "application/octet-stream")` is set on the `RequestBuilder`.

I can't get it to work. 

I think that similar stuff used to work in the past, when there was only one GET in establishing the connection and no stuff being sent back for LONG-POLLING in connection establishment.

Thanks for investigating. 
