### PR TITLE
TransportNotSupported exception should have getter for statusCode

### DIFF
--- a/wasync/src/main/java/org/atmosphere/wasync/transport/TransportNotSupported.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/transport/TransportNotSupported.java
@@ -40,4 +40,8 @@ public class TransportNotSupported extends Exception {
     public String toString(){
         return "Connection Error " + statusCode + " : " + reasonPhrase;
     }
+
+    public int getStatusCode(){
+        return statusCode;
+    }
 }


### PR DESCRIPTION
Sometimes you need to know underlying HTTP status code (e.g. 401) to properly handle WebSocket exception.
