### PR TITLE
Surefire plugin forkMode setting seems to make tests deterministic.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.8.1</version>
                 <configuration>
+                    <forkMode>never</forkMode>
                     <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Tests are very non-deterministic for me. Usually a sign of concurrency issues. This makes the tests deterministic in my environment.
