### PR TITLE
Test case for not closing AHC when using SerializedClient

### DIFF
--- a/wasync/src/test/java/org/atmosphere/tests/BaseTest.java
+++ b/wasync/src/test/java/org/atmosphere/tests/BaseTest.java
@@ -2346,6 +2346,52 @@ public abstract class BaseTest {
         assertTrue(ahc.isClosed());
     }
 
+    @Test
+    public void ahcCloseTest2() throws IOException, InterruptedException {
+        Config config = new Config.Builder()
+                .port(port)
+                .host("127.0.0.1")
+                .resource("/suspend", new AtmosphereHandler() {
+
+                    private final AtomicBoolean b = new AtomicBoolean(false);
+
+                    @Override
+                    public void onRequest(AtmosphereResource r) throws IOException {
+                        r.suspend();
+                    }
+
+                    @Override
+                    public void onStateChange(AtmosphereResourceEvent r) throws IOException {
+                    }
+
+                    @Override
+                    public void destroy() {
+
+                    }
+                }).build();
+
+        server = new Nettosphere.Builder().config(config).build();
+        assertNotNull(server);
+        server.start();
+
+        final AsyncHttpClient ahc = new AsyncHttpClient(new AsyncHttpClientConfig.Builder().setMaxRequestRetry(0).build());
+        SerializedClient client = ClientFactory.getDefault().newClient(SerializedClient.class);
+
+        RequestBuilder request = client.newRequestBuilder()
+                .method(Request.METHOD.GET)
+                .uri(targetUrl + "/suspend")
+                .transport(Request.TRANSPORT.WEBSOCKET);
+
+        Socket socket = client.create(client.newOptionsBuilder().serializedFireStage(new DefaultSerializedFireStage()).build());
+        socket.open(request.build());
+        socket.close();
+
+        // AHC is async closed
+        Thread.sleep(1000);
+
+        assertTrue(ahc.isClosed());
+    }
+
 
     public final static class EventPOJO {
 


### PR DESCRIPTION
The internally created (not shared) AsyncHttpClient is not closed when using SerializedClient. It's probably related to issue #87.

This pull request adds a test case for it which is the same as "ahcCloseTest" except it's using a SerializedClient with DefaultSerializedFireStage.

Let me know if you would rather have an issue opened.
