### PR TITLE
Fix test case for #89

### DIFF
--- a/wasync/src/test/java/org/atmosphere/tests/BaseTest.java
+++ b/wasync/src/test/java/org/atmosphere/tests/BaseTest.java
@@ -21,6 +21,7 @@ import org.atmosphere.wasync.Socket;
 import org.atmosphere.wasync.impl.AtmosphereClient;
 import org.atmosphere.wasync.serial.DefaultSerializedFireStage;
 import org.atmosphere.wasync.serial.SerializedClient;
+import org.atmosphere.wasync.serial.SerializedOptions;
 import org.atmosphere.wasync.serial.SerializedOptionsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -2494,7 +2495,6 @@ public abstract class BaseTest {
         assertNotNull(server);
         server.start();
 
-        final AsyncHttpClient ahc = new AsyncHttpClient(new AsyncHttpClientConfig.Builder().setMaxRequestRetry(0).build());
         SerializedClient client = ClientFactory.getDefault().newClient(SerializedClient.class);
 
         RequestBuilder request = client.newRequestBuilder()
@@ -2502,14 +2502,15 @@ public abstract class BaseTest {
                 .uri(targetUrl + "/suspend")
                 .transport(Request.TRANSPORT.WEBSOCKET);
 
-        Socket socket = client.create(client.newOptionsBuilder().runtime(ahc).runtimeShared(false).serializedFireStage(new DefaultSerializedFireStage()).build());
+        SerializedOptions options = client.newOptionsBuilder().serializedFireStage(new DefaultSerializedFireStage()).build();
+        Socket socket = client.create(options);
         socket.open(request.build());
         socket.close();
 
         // AHC is async closed
         Thread.sleep(1000);
 
-        assertTrue(ahc.isClosed());
+        assertTrue(options.runtime().isClosed());
     }
 
     public final static class EventPOJO {


### PR DESCRIPTION
This test case checks if the internally created AHC is closed when using
SerializedClient.

This commit show what I really meant in #89. I believe this test case should pass, but it doesn't.

Let me know if you would rather have a new test case and leave the current "ahcCloseTest2" as is.