### PR TITLE
Proper AsyncHttpClient runtime handling in SerializedSocket.

### DIFF
--- a/wasync/src/main/java/org/atmosphere/wasync/serial/SerializedClient.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/serial/SerializedClient.java
@@ -15,12 +15,10 @@
  */
 package org.atmosphere.wasync.serial;
 
-import com.ning.http.client.AsyncHttpClient;
 import org.atmosphere.wasync.Client;
 import org.atmosphere.wasync.FunctionResolver;
 import org.atmosphere.wasync.Socket;
 import org.atmosphere.wasync.impl.AtmosphereRequest.AtmosphereRequestBuilder;
-import org.atmosphere.wasync.impl.ClientUtil;
 
 /**
  * {@code SerializedClient} is a {@link org.atmosphere.wasync.Client} that guarantees ordered message delivery, in-line with the
@@ -48,11 +46,6 @@ public class SerializedClient implements Client<SerializedOptions, SerializedOpt
      */
     @Override
     public Socket create(SerializedOptions options) {
-        AsyncHttpClient asyncHttpClient = options.runtime();
-        if (asyncHttpClient == null || asyncHttpClient.isClosed()) {
-            asyncHttpClient = ClientUtil.createDefaultAsyncHttpClient(options);
-            options.runtime(asyncHttpClient);
-        }
         return new SerializedSocket(options);
     }
 
@@ -61,11 +54,8 @@ public class SerializedClient implements Client<SerializedOptions, SerializedOpt
      */
     @Override
     public Socket create() {
-        AsyncHttpClient asyncHttpClient = ClientUtil.createDefaultAsyncHttpClient(newOptionsBuilder().reconnect(true).build());
-
         return new SerializedSocket(
                 new SerializedOptionsBuilder()
-                        .runtime(asyncHttpClient)
                         .serializedFireStage(new DefaultSerializedFireStage())
                         .build());
     }

--- a/wasync/src/main/java/org/atmosphere/wasync/serial/SerializedSocket.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/serial/SerializedSocket.java
@@ -15,19 +15,22 @@
  */
 package org.atmosphere.wasync.serial;
 
-import com.ning.http.client.ListenableFuture;
-import com.ning.http.client.Response;
+import java.io.IOException;
+import java.util.List;
+
 import org.atmosphere.wasync.FunctionWrapper;
 import org.atmosphere.wasync.Options;
 import org.atmosphere.wasync.Socket;
+import org.atmosphere.wasync.impl.ClientUtil;
 import org.atmosphere.wasync.impl.DefaultFuture;
 import org.atmosphere.wasync.impl.DefaultSocket;
 import org.atmosphere.wasync.impl.SocketRuntime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.List;
+import com.ning.http.client.AsyncHttpClient;
+import com.ning.http.client.ListenableFuture;
+import com.ning.http.client.Response;
 
 /**
  * {@code SerializedSocket} is a {@link Socket} implementation that guarantees ordered message delivery of
@@ -38,20 +41,27 @@ import java.util.List;
  * <p/>
  *
  * @author Christian Bach
- * @author Christian Bach
  */
 public class SerializedSocket extends DefaultSocket {
 
     private final static Logger logger = LoggerFactory.getLogger(SerializedSocket.class);
 
     private SerializedFireStage serializedFireStage;
-
+    private AsyncHttpClient asyncHttpClient;
+    
     public SerializedSocket(SerializedOptions options) {
         super(options);
+        if (options.runtime() == null || options.runtime().isClosed()) {
+            asyncHttpClient = ClientUtil.createDefaultAsyncHttpClient(options);
+            options.runtime(asyncHttpClient);
+        }
         this.serializedFireStage = options.serializedFireStage();
         this.serializedFireStage.setSocket(this);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public SocketRuntime createRuntime(DefaultFuture future, Options options, List<FunctionWrapper> functions) {
         return new SerialSocketRuntime(transportInUse, options, new DefaultFuture(this), this, functions);
@@ -64,4 +74,17 @@ public class SerializedSocket extends DefaultSocket {
     public ListenableFuture<Response> directWrite(Object encodedPayload) throws IOException {
         return socketRuntime.httpWrite(request, encodedPayload, encodedPayload);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+    	serializedFireStage.shutdown();
+    	if (asyncHttpClient != null) {
+    		asyncHttpClient.close();
+    	}
+    	super.close();
+    }
+    
 }


### PR DESCRIPTION
Improve `SerializedSocket` (and `SerializedClient`) by 
- proper `AsyncHttpClient` runtime resource handling in the `SerializedSocket`
- shutting down the configured `SerializedFireStage`
