### PR TITLE
StreamTransport::close() seems to be misaligned.

### DIFF
--- a/wasync/src/main/java/org/atmosphere/wasync/Options.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/Options.java
@@ -38,11 +38,11 @@ public interface Options {
     public boolean reconnect();
 
     /**
-     * The delay, in second, before reconnecting.
+     * The delay, in milliseconds, before reconnecting.
      *
-     * @return The delay, in second, before reconnecting.
+     * @return The delay, in millisecond, before reconnecting.
      */
-    public int reconnectInSeconds();
+    public int reconnectTimeoutInMilliseconds();
 
     /**
      * Maximum reconnection attempts that will run in the interval defined by {@link #reconnectInSeconds}

--- a/wasync/src/main/java/org/atmosphere/wasync/OptionsBuilder.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/OptionsBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.atmosphere.wasync;
 
+import com.ning.http.client.AsyncHttpClient;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/wasync/src/main/java/org/atmosphere/wasync/OptionsBuilder.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/OptionsBuilder.java
@@ -15,7 +15,7 @@
  */
 package org.atmosphere.wasync;
 
-import com.ning.http.client.AsyncHttpClient;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Base class for building {@link Options}
@@ -27,7 +27,7 @@ public abstract class OptionsBuilder<U extends Options, T extends OptionsBuilder
 
     private Transport transport;
     private boolean reconnect = true;
-    private int reconnectInSecond = 0;
+    private int reconnectTimeoutInMilliseconds = 0;
     private int reconnectAttempts = 0;
     private long waitBeforeUnlocking = 2000;
     private AsyncHttpClient client;
@@ -74,13 +74,24 @@ public abstract class OptionsBuilder<U extends Options, T extends OptionsBuilder
     }
 
     /**
-     * The time in second, before the reconnection occurs. Default is 1 second
+     * The time in seconds, before the reconnection occurs. Default is instant(0).
      *
-     * @param reconnectInSecond time in second, before the reconnection occurs. Default is 1 second
+     * @param reconnectInSecond time in seconds, before the reconnection occurs. Default is instant.
      * @return this
      */
     public T pauseBeforeReconnectInSeconds(int reconnectInSecond) {
-        this.reconnectInSecond = reconnectInSecond;
+        this.reconnectTimeoutInMilliseconds = TimeUnit.SECONDS.toMillis(reconnectInSecond);
+        return derived.cast(this);
+    }
+    
+    /**
+     * The time in milliseconds, before the reconnection occurs. Default is instant(0).
+     *
+     * @param reconnectTimeoutInMilliseconds time in milliseconds, before the reconnection occurs. Default is instant.
+     * @return this
+     */
+    public T pauseBeforeReconnectInMilliseconds(int reconnectTimeoutInMilliseconds) {
+        this.reconnectTimeoutInMilliseconds = reconnectTimeoutInMilliseconds;
         return derived.cast(this);
     }
 
@@ -167,11 +178,11 @@ public abstract class OptionsBuilder<U extends Options, T extends OptionsBuilder
         return reconnect;
     }
     /**
-     * The delay, in second, before reconnecting.
-     * @return The delay, in second, before reconnecting.
+     * The delay, in milliseconds, before reconnecting.
+     * @return The delay, in milliseconds, before reconnecting.
      */
-    public int reconnectInSeconds(){
-        return reconnectInSecond;
+    public int reconnectTimeoutInMilliseconds(){
+        return reconnectTimeoutInMilliseconds;
     }
 
     /**

--- a/wasync/src/main/java/org/atmosphere/wasync/impl/DefaultOptions.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/impl/DefaultOptions.java
@@ -51,8 +51,8 @@ public class DefaultOptions implements Options {
      * {@inheritDoc}
      */
     @Override
-    public int reconnectInSeconds(){
-        return b.reconnectInSeconds();
+    public int reconnectTimeoutInMilliseconds(){
+        return b.reconnectTimeoutInMilliseconds();
     }
 
     @Override

--- a/wasync/src/main/java/org/atmosphere/wasync/transport/StreamTransport.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/transport/StreamTransport.java
@@ -219,6 +219,8 @@ public class StreamTransport implements AsyncHandler<String>, Transport {
         if (status == Socket.STATUS.ERROR) {
             return "";
         }
+        
+        close();
 
         if (options.reconnect()) {
             // We can't let the STATUS to close as fire() method won't work.
@@ -232,9 +234,7 @@ public class StreamTransport implements AsyncHandler<String>, Transport {
             } else {
                 reconnect();
             }
-        } else {
-            close();
-        }
+        } 
         return "";
     }
 

--- a/wasync/src/main/java/org/atmosphere/wasync/transport/StreamTransport.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/transport/StreamTransport.java
@@ -220,8 +220,6 @@ public class StreamTransport implements AsyncHandler<String>, Transport {
             return "";
         }
 
-        close();
-
         if (options.reconnect()) {
             // We can't let the STATUS to close as fire() method won't work.
             status = Socket.STATUS.REOPENED;
@@ -234,6 +232,8 @@ public class StreamTransport implements AsyncHandler<String>, Transport {
             } else {
                 reconnect();
             }
+        } else {
+            close();
         }
         return "";
     }


### PR DESCRIPTION
```StreamTransport::close()``` is currently invoked after every completed GET, while it is having an implementation that asks for a one-time, terminal invocation only.