### PR TITLE
Prevent potential NullPointerException on close()

### DIFF
--- a/wasync/src/main/java/org/atmosphere/wasync/impl/AtmosphereSocket.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/impl/AtmosphereSocket.java
@@ -111,7 +111,9 @@ public class AtmosphereSocket extends DefaultSocket {
      */
     @Override
     public void close() {
-        doCloseRequest();
+        if(request != null) {
+            doCloseRequest();
+        }
 
         // Not connected, but close the underlying AHC.
         if (transportInUse == null) {


### PR DESCRIPTION
If an `AtmosphereSocket` is created, but never opened, its `request` is never initialized; this leads to a potential `NullPointerException` being thrown if `close()` is called against the Socket, from line 56 (`decodeQueryString` call).