### PR TITLE
fix a bug in the replay treatment in TransportsUtil.java

### DIFF
--- a/wasync/src/main/java/org/atmosphere/wasync/transport/TransportsUtil.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/transport/TransportsUtil.java
@@ -172,10 +172,12 @@ public class TransportsUtil {
                         return l;
                     }
 
+                    ArrayList<Object> list = new ArrayList<Object>();
                     for (Object m : l) {
-                        return matchDecoder(e, m, nd, decodedObjects);
+                            list.add(matchDecoder(e, m, nd, decodedObjects));
                     }
-                } else if (decoded != null) {
+                    return list;
+		} else if (decoded != null) {
                     logger.trace("Decoder {} match {}", d, instanceType);
                     decodedObjects.add(decoded);
                 }


### PR DESCRIPTION
The replay treatment was not well handled in TransportsUtil.java.
Some messages may be lost because of that bug.

