### PR TITLE
fix TrackMessageSizeDecoder

### DIFF
--- a/wasync/src/main/java/org/atmosphere/wasync/decoder/TrackMessageSizeDecoder.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/decoder/TrackMessageSizeDecoder.java
@@ -20,7 +20,12 @@ import org.atmosphere.wasync.ReplayDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;

--- a/wasync/src/main/java/org/atmosphere/wasync/decoder/TrackMessageSizeDecoder.java
+++ b/wasync/src/main/java/org/atmosphere/wasync/decoder/TrackMessageSizeDecoder.java
@@ -15,15 +15,15 @@
  */
 package org.atmosphere.wasync.decoder;
 
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.atmosphere.wasync.Event;
 import org.atmosphere.wasync.ReplayDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 public class TrackMessageSizeDecoder implements ReplayDecoder<String, String> {
 
@@ -32,12 +32,10 @@ public class TrackMessageSizeDecoder implements ReplayDecoder<String, String> {
     private final String delimiter;
     private final StringBuffer messagesBuffer = new StringBuffer();
     private final AtomicBoolean skipFirstMessage = new AtomicBoolean();
-    private final Decoded<List<String>> empty = new Decoded<List<String>>(Collections.<String>emptyList());
-
-    private final static String charReplacement = "!!&;_!!";
+    private final Decoded<List<String>> empty = new Decoded<>(Collections.emptyList());
 
     public TrackMessageSizeDecoder() {
-        this.delimiter = "|";
+        this.delimiter = String.format("\\%s", "|");
     }
 
     public TrackMessageSizeDecoder(boolean protocolEnabled) {
@@ -51,48 +49,122 @@ public class TrackMessageSizeDecoder implements ReplayDecoder<String, String> {
     }
 
     @Override
-    public Decoded<List<String>> decode(Event type, String message) {
-        if (type.equals(Event.MESSAGE)) {
+    public Decoded<List<String>> decode(Event eventType, String message) {
+        return decodeMessageIfEventIsTypeMessage(eventType, message);
+    }
 
-            if (skipFirstMessage.getAndSet(false)) return empty;
-            Decoded<List<String>> messages = new Decoded<List<String>>(new LinkedList<String>());
-
-            message = messagesBuffer.append(message).toString().replace(delimiter, charReplacement);
-            messagesBuffer.setLength(0);
-
-            if (message.indexOf(charReplacement) != -1) {
-                String[] tokens = message.split(charReplacement);
-
-                // Skip first.
-                int pos = 1;
-                int length = Integer.valueOf(tokens[0]);
-                String m;
-                while (pos < tokens.length) {
-                    m = tokens[pos];
-                    if (m.length() >= length) {
-                    	messages.decoded().add(m.substring(0, length));
-                        String t = m.substring(length);
-                        if (t.length() > 0) {
-                            length = Integer.valueOf(t);
-                        }
-                    } else {
-                        if (pos != 1) {
-                            messagesBuffer.append(length).append(delimiter).append(m);
-                        } else {
-                            messagesBuffer.append(message);
-                        }
-                        if (messages.decoded().size() > 0) {
-                        	return messages;
-                        } else {
-                        	return new Decoded<List<String>>(new LinkedList<String>(), Decoded.ACTION.ABORT);
-                        }
-                    }
-                    pos++;
-                }
-            }
-            return messages;
-        } else {
+    private Decoded<List<String>> decodeMessageIfEventIsTypeMessage(Event eventType, String message) {
+        if (isEventTypeNotMessageOrFirstMessageSkipped(eventType)) {
             return empty;
         }
+
+        return decodeMessage().apply(message);
+    }
+
+    private boolean isEventTypeNotMessageOrFirstMessageSkipped(Event eventType) {
+        return !isMessageEvent(eventType) || skipFirstMessage.getAndSet(false);
+    }
+
+    private Function<String, Decoded<List<String>>> decodeMessage() {
+        return constructDecodedListFromMessageList()
+                .compose(constructListOfMessages())
+                .compose(separateSizeAndPayload())
+                .compose(assembleIncompleteMessage());
+    }
+
+    private boolean isMessageEvent(Event event) {
+        return event.equals(Event.MESSAGE);
+    }
+
+    private Function<String, String> assembleIncompleteMessage() {
+        return (message) -> {
+            message = messagesBuffer.append(message).toString();
+            messagesBuffer.setLength(0);
+            return message;
+        };
+    }
+
+    private Function<String, String[]> separateSizeAndPayload() {
+        return (message) -> message.split(String.format("\\%s", delimiter), 2);
+    }
+
+    private Function<String[], List<String>> constructListOfMessages() {
+        return (message) -> {
+            if (doesMessageContainMessageLength().and(messageContainDelimiter()).test(message)) {
+                return addCompleteMessageToListRecursive()
+                        .compose(readMessageContentIntoMap())
+                        .apply(message);
+            } else {
+                messagesBuffer.append(message[0]);
+                return new LinkedList<>();
+            }
+        };
+    }
+
+    private Predicate<String[]> doesMessageContainMessageLength() {
+        return messageList -> convertPayloadSizeFromStringToInt(messageList[0]).isPresent();
+    }
+
+    private Predicate<String[]> messageContainDelimiter() {
+        return messageList -> messageList.length > 1;
+    }
+
+    private Function<List<String>, Decoded<List<String>>> constructDecodedListFromMessageList() {
+        return Decoded::new;
+    }
+
+    private Function<Map<String, String>, List<String>> addCompleteMessageToListRecursive() {
+        return extractedAndRemainingMessage -> {
+            Optional<Integer> payloadSize = convertPayloadSizeFromStringToInt(extractedAndRemainingMessage.get("payloadSize"));
+            return payloadSize
+                    .map(messageLength -> convertMappedMessagesToMessageList(extractedAndRemainingMessage, messageLength))
+                    .orElseGet(LinkedList::new);
+        };
+    }
+
+    private List<String> convertMappedMessagesToMessageList(Map<String, String> extractedAndRemainingMessage, Integer messageLength) {
+        List<String> messageList = new LinkedList<>();
+
+        if (extractedAndRemainingMessage.get("extractedMessage").length() == messageLength) {
+            messageList.add(extractedAndRemainingMessage.get("extractedMessage"));
+        }
+
+        if (!extractedAndRemainingMessage.get("remainingMessage").isEmpty()) {
+            messageList.addAll(
+                    constructListOfMessages()
+                            .compose(separateSizeAndPayload())
+                            .apply(extractedAndRemainingMessage.get("remainingMessage"))
+            );
+        }
+        return messageList;
+    }
+
+    private Optional<Integer> convertPayloadSizeFromStringToInt(String message) {
+        try {
+            return Optional.of(Integer.valueOf(message));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    private Function<String[], Map<String, String>> readMessageContentIntoMap() {
+        return (message) -> {
+            Map<String, String> messageMap = new HashMap<>();
+            Optional<Integer> payloadSize = convertPayloadSizeFromStringToInt(message[0]);
+
+            payloadSize.ifPresent(messageLength -> {
+                messageMap.put("payloadSize", message[0]);
+                if (message[1].length() >= messageLength) {
+                    messageMap.put("extractedMessage", message[1].substring(0, messageLength));
+                    messageMap.put("remainingMessage", message[1].substring(messageLength));
+                } else {
+                    messagesBuffer.append(messageMap.get("payloadSize")).append(delimiter).append(message[1]);
+                    messageMap.put("extractedMessage", message[1]);
+                    messageMap.put("remainingMessage", "");
+                }
+            });
+
+            return messageMap;
+        };
     }
 }


### PR DESCRIPTION
Messages containing the delimiter now parse correctly. The decoder now handles more edge cases correctly, making it more robust.